### PR TITLE
Palette fixes from upstream

### DIFF
--- a/libsmacker/smacker.c
+++ b/libsmacker/smacker.c
@@ -765,12 +765,6 @@ static char smk_render_palette(struct smk_video_t *s, unsigned char *p, unsigned
 	i = 0; /* index into NEW palette */
 	j = 0; /* Index into OLD palette */
 
-	/* If old palette exists already, copy it first */
-	if (s->palette)
-	{
-		memcpy(t,s->palette, 3 * 256 );
-	}
-
 	while ( (i < 768) && (size > 0) ) /* looping index into NEW palette */
 	{
 		if ((*p) & 0x80)
@@ -781,24 +775,23 @@ static char smk_render_palette(struct smk_video_t *s, unsigned char *p, unsigned
 			p ++; size --;
 
 			/* check for overflow condition */
-			if (j + k > 768 || i + k > 768)
+			if (i + k > 768)
 			{
-				fprintf(stderr,"libsmacker::palette_render(s,p,size) - ERROR: overflow, 0x80 attempt to copy %d bytes from %d to %d\n",k,j,i);
+				fprintf(stderr,"libsmacker::palette_render(s,p,size) - ERROR: overflow, 0x80 attempt to copy %d bytes from %d\n",k,i);
 				goto error;
 			}
 
 			/* if prev palette exists, copy... else memset black */
-			/*if (s->palette)
+			if (s->palette)
 			{
-				memcpy(&t[i],&s->palette[j],k);
-			} */
+				memcpy(&t[i],&s->palette[i],k);
+			}
 			/* smkmalloc already set t to 0 */
 			/* else
 			{
 				memset(&t[i],0,k);
 			} */
 			i += k;
-			j += k;
 		}
 		else if ((*p) & 0x40)
 		{


### PR DESCRIPTION
libsmacker r26 includes fixes to palette handling.  This corrects some areas where pixels appeared all-black in playback videos.
